### PR TITLE
メモリリーク対処と型定義・エラー処理強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ THQ handles three main types of telemetry events:
 ```typescript
 {
   id: string;
-  lat: number | null;
-  lon: number | null;
+  lat: number;
+  lon: number;
   accuracy: number | null;
-  speed: number | null;
+  speed: number;
   timestamp: number;
   state: "arrived" | "approaching" | "passing" | "moving";
   device: string;
@@ -193,10 +193,11 @@ THQ uses a JSON-based WebSocket protocol for communication:
 }
 ```
 
-**Location update (client to server):**
+**Location update:**
 
 ```json
 {
+  "id": "generated-id",
   "type": "location_update",
   "device": "device-id",
   "state": "moving",
@@ -210,28 +211,11 @@ THQ uses a JSON-based WebSocket protocol for communication:
 }
 ```
 
-**Location update (server to subscribers):**
+**Log message:**
 
 ```json
 {
-  "id": "unique-id",
-  "type": "location_update",
-  "device": "device-id",
-  "state": "moving",
-  "coords": {
-    "latitude": 35.0,
-    "longitude": 139.0,
-    "accuracy": 5.0,
-    "speed": 10.0
-  },
-  "timestamp": 1234567890
-}
-```
-
-**Log message (client to server):**
-
-```json
-{
+  "id": "generated-id",
   "type": "log",
   "device": "device-id",
   "timestamp": 1234567890,
@@ -239,34 +223,6 @@ THQ uses a JSON-based WebSocket protocol for communication:
     "type": "system",
     "level": "info",
     "message": "System operational"
-  }
-}
-```
-
-**Log message (server to subscribers):**
-
-```json
-{
-  "id": "unique-id",
-  "type": "log",
-  "device": "device-id",
-  "timestamp": 1234567890,
-  "log": {
-    "type": "system",
-    "level": "info",
-    "message": "System operational"
-  }
-}
-```
-
-**Error message:**
-
-```json
-{
-  "type": "error",
-  "data": {
-    "type": "json_parse_error",
-    "reason": "Failed to parse JSON: Unexpected token"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ THQ handles three main types of telemetry events:
 ```typescript
 {
   id: string;
-  type: "system";
+  type: "system" | "app" | "client";
   timestamp: number;
   level: "debug" | "info" | "warn" | "error";
   message: string;
@@ -157,8 +157,13 @@ THQ handles three main types of telemetry events:
 
 ```typescript
 {
-  type: "accuracy_low" | "invalid_coords" | "unknown";
-  raw: any;
+  type: "websocket_message_error" |
+    "json_parse_error" |
+    "payload_parse_error" |
+    "accuracy_low" |
+    "invalid_coords" |
+    "unknown";
+  reason: string;
 }
 ```
 
@@ -188,7 +193,7 @@ THQ uses a JSON-based WebSocket protocol for communication:
 }
 ```
 
-**Location update:**
+**Location update (client to server):**
 
 ```json
 {
@@ -205,7 +210,25 @@ THQ uses a JSON-based WebSocket protocol for communication:
 }
 ```
 
-**Log message:**
+**Location update (server to subscribers):**
+
+```json
+{
+  "id": "unique-id",
+  "type": "location_update",
+  "device": "device-id",
+  "state": "moving",
+  "coords": {
+    "latitude": 35.0,
+    "longitude": 139.0,
+    "accuracy": 5.0,
+    "speed": 10.0
+  },
+  "timestamp": 1234567890
+}
+```
+
+**Log message (client to server):**
 
 ```json
 {
@@ -216,6 +239,34 @@ THQ uses a JSON-based WebSocket protocol for communication:
     "type": "system",
     "level": "info",
     "message": "System operational"
+  }
+}
+```
+
+**Log message (server to subscribers):**
+
+```json
+{
+  "id": "unique-id",
+  "type": "log",
+  "device": "device-id",
+  "timestamp": 1234567890,
+  "log": {
+    "type": "system",
+    "level": "info",
+    "message": "System operational"
+  }
+}
+```
+
+**Error message:**
+
+```json
+{
+  "type": "error",
+  "data": {
+    "type": "json_parse_error",
+    "reason": "Failed to parse JSON: Unexpected token"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ THQ handles three main types of telemetry events:
 ```typescript
 {
   id: string;
+  type: "system";
   timestamp: number;
   level: "debug" | "info" | "warn" | "error";
   message: string;
@@ -212,6 +213,7 @@ THQ uses a JSON-based WebSocket protocol for communication:
   "device": "device-id",
   "timestamp": 1234567890,
   "log": {
+    "type": "system",
     "level": "info",
     "message": "System operational"
   }

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ THQ implements comprehensive error handling for:
 ## 📊 Performance
 
 - Maintains up to 1,000 telemetry records in memory
-- Automatic deduplication of telemetry data
+- Bounded append with capacity limit (keeps the latest 1,000 entries; no dedup)
 - Efficient real-time updates using Jotai state management
 - Optimized rendering with React.memo and useMemo
 

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -26,7 +26,7 @@ pub struct LocationData {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorData {
     pub r#type: String,
-    pub raw: serde_json::Value,
+    pub reason: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/ws_client.rs
+++ b/src-tauri/src/ws_client.rs
@@ -38,7 +38,7 @@ pub async fn start_ws_client(app: Arc<AppHandle>) {
                                         &(*app),
                                         &TelemetryEvent::Error(ErrorData {
                                             r#type: "websocket_message_error".to_string(),
-                                            raw: json!({ "error": e.to_string() }),
+                                            reason: format!("Failed to parse message: {}", e),
                                         }),
                                     );
                                     continue;
@@ -52,7 +52,7 @@ pub async fn start_ws_client(app: Arc<AppHandle>) {
                                         &(*app),
                                         &TelemetryEvent::Error(ErrorData {
                                             r#type: "json_parse_error".to_string(),
-                                            raw: json!({ "error": e.to_string() }),
+                                            reason: format!("Failed to parse JSON: {}", e),
                                         }),
                                     );
                                     continue;
@@ -157,10 +157,7 @@ pub async fn start_ws_client(app: Arc<AppHandle>) {
                                 }
                                 t => TelemetryEvent::Error(ErrorData {
                                     r#type: "unknown".to_string(),
-                                    raw: json!({
-                                        "error": format!("Unknown event type: {}", t),
-                                        "raw": value.to_string(),
-                                    }),
+                                    reason: format!("Unknown event type: {}", t),
                                 }),
                             };
 

--- a/src-tauri/src/ws_client.rs
+++ b/src-tauri/src/ws_client.rs
@@ -75,7 +75,7 @@ pub async fn start_ws_client(app: Arc<AppHandle>) {
 
                                     TelemetryEvent::LogUpdate(LogData {
                                         id: id_value.to_string(),
-                                        r#type: "log".to_string(),
+                                        r#type: "system".to_string(),
                                         timestamp: timestamp_value.as_u64().unwrap(),
                                         level: level_value.to_string(),
                                         message: message_value.to_string(),

--- a/src-tauri/src/ws_client.rs
+++ b/src-tauri/src/ws_client.rs
@@ -31,7 +31,21 @@ pub async fn start_ws_client(app: Arc<AppHandle>) {
                 while let Some(msg_result) = ws_stream.next().await {
                     match msg_result {
                         Ok(msg) => {
-                            let value: Value = match serde_json::from_str(msg.to_text().unwrap()) {
+                            let text = match msg.to_text() {
+                                Ok(t) => t,
+                                Err(e) => {
+                                    emit_event(
+                                        &(*app),
+                                        &TelemetryEvent::Error(ErrorData {
+                                            r#type: "websocket_message_error".to_string(),
+                                            raw: json!({ "error": e.to_string() }),
+                                        }),
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let value: Value = match serde_json::from_str(text) {
                                 Ok(v) => v,
                                 Err(e) => {
                                     emit_event(
@@ -49,34 +63,93 @@ pub async fn start_ws_client(app: Arc<AppHandle>) {
 
                             let event = match value_type {
                                 "location_update" => {
-                                    let id_value = value["id"].as_str().unwrap();
-                                    let device_id_value = value["device"].as_str().unwrap();
-                                    let state_value = value["state"].as_str().unwrap();
+                                    let id_value = match value.get("id").and_then(Value::as_str) {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let device_id_value =
+                                        match value.get("device").and_then(Value::as_str) {
+                                            Some(v) => v,
+                                            None => continue,
+                                        };
+                                    let state_value =
+                                        match value.get("state").and_then(Value::as_str) {
+                                            Some(v) => v,
+                                            None => continue,
+                                        };
                                     let coords_value = value["coords"].clone();
-                                    let timestamp_value = value["timestamp"].clone();
+                                    let timestamp_value = match value.get("timestamp") {
+                                        Some(v) => v.clone(),
+                                        None => continue,
+                                    };
+
+                                    let lat = match coords_value["latitude"].as_f64() {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let lon = match coords_value["longitude"].as_f64() {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let accuracy = coords_value["accuracy"].as_f64();
+                                    let speed = match coords_value["speed"].as_f64() {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let timestamp = match timestamp_value.as_u64() {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
 
                                     TelemetryEvent::LocationUpdate(LocationData {
                                         id: id_value.to_string(),
-                                        lat: coords_value["latitude"].as_f64().unwrap(),
-                                        lon: coords_value["longitude"].as_f64().unwrap(),
-                                        accuracy: coords_value["accuracy"].as_f64(),
-                                        speed: coords_value["speed"].as_f64().unwrap(),
+                                        lat,
+                                        lon,
+                                        accuracy,
+                                        speed,
                                         device: device_id_value.to_string(),
                                         state: state_value.to_string(),
-                                        timestamp: timestamp_value.as_u64().unwrap(),
+                                        timestamp,
                                     })
                                 }
                                 "log" => {
-                                    let id_value = value["id"].as_str().unwrap();
-                                    let timestamp_value = value["timestamp"].clone();
-                                    let level_value = value["level"].as_str().unwrap();
-                                    let message_value = value["message"].as_str().unwrap();
-                                    let device_id_value = value["device"].as_str().unwrap();
+                                    let id_value = match value.get("id").and_then(Value::as_str) {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let device_id_value =
+                                        match value.get("device").and_then(Value::as_str) {
+                                            Some(v) => v,
+                                            None => continue,
+                                        };
+                                    let type_value = match value.get("type").and_then(Value::as_str)
+                                    {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let unchecked_timestamp_value = match value.get("timestamp") {
+                                        Some(v) => v.clone().as_u64(),
+                                        None => continue,
+                                    };
+                                    let timestamp_value = match unchecked_timestamp_value {
+                                        Some(v) => v,
+                                        None => continue,
+                                    };
+                                    let level_value =
+                                        match value.get("level").and_then(Value::as_str) {
+                                            Some(v) => v,
+                                            None => continue,
+                                        };
+                                    let message_value =
+                                        match value.get("message").and_then(Value::as_str) {
+                                            Some(v) => v,
+                                            None => continue,
+                                        };
 
                                     TelemetryEvent::LogUpdate(LogData {
                                         id: id_value.to_string(),
-                                        r#type: "system".to_string(),
-                                        timestamp: timestamp_value.as_u64().unwrap(),
+                                        r#type: type_value.to_string(),
+                                        timestamp: timestamp_value,
                                         level: level_value.to_string(),
                                         message: message_value.to_string(),
                                         device: device_id_value.to_string(),

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -144,7 +144,7 @@ async fn handle_connection(
                     (
                         TelemetryEvent::LogUpdate(LogData {
                             id: nanoid::nanoid!(),
-                            r#type: "log".to_string(),
+                            r#type: "system".to_string(),
                             timestamp,
                             level: level.clone(),
                             message: message.clone(),
@@ -167,7 +167,7 @@ async fn handle_connection(
                 Some("subscribe") => (
                     TelemetryEvent::LogUpdate(LogData {
                         id: nanoid::nanoid!(),
-                        r#type: "log".to_string(),
+                        r#type: "system".to_string(),
                         timestamp: chrono::Utc::now().timestamp_millis() as u64,
                         level: "info".to_string(),
                         message: "New subscriber added.".to_string(),

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -313,31 +313,34 @@ async fn handle_connection(
                         ),
                     )
                 }
-                Some("subscribe") => (
-                    TelemetryEvent::LogUpdate(LogData {
-                        id: nanoid::nanoid!(),
-                        r#type: "system".to_string(),
-                        timestamp: chrono::Utc::now().timestamp_millis() as u64,
-                        level: "info".to_string(),
-                        message: "New subscriber added.".to_string(),
-                        device: "THQ Client".to_string(),
-                    }),
-                    Message::Text(
-                        serde_json::json!({
-                            "id": nanoid::nanoid!(),
-                            "type": "log",
-                            "device": "THQ Client",
-                            "timestamp": chrono::Utc::now().timestamp_millis() as u64,
-                            "log": {
-                                "type": "system",
-                                "level": "info",
-                                "message": "New subscriber added."
-                            }
-                        })
-                        .to_string()
-                        .into(),
-                    ),
-                ),
+                Some("subscribe") => {
+                    let now = chrono::Utc::now().timestamp_millis() as u64;
+                    (
+                        TelemetryEvent::LogUpdate(LogData {
+                            id: nanoid::nanoid!(),
+                            r#type: "system".to_string(),
+                            timestamp: now,
+                            level: "info".to_string(),
+                            message: "New subscriber added.".to_string(),
+                            device: "THQ Client".to_string(),
+                        }),
+                        Message::Text(
+                            serde_json::json!({
+                                "id": nanoid::nanoid!(),
+                                "type": "log",
+                                "device": "THQ Client",
+                                "timestamp": now,
+                                "log": {
+                                    "type": "system",
+                                    "level": "info",
+                                    "message": "New subscriber added."
+                                }
+                            })
+                            .to_string()
+                            .into(),
+                        ),
+                    )
+                }
                 txt => (
                     TelemetryEvent::Error(ErrorData {
                         r#type: "unknown".to_string(),

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -346,7 +346,10 @@ async fn handle_connection(
                     Message::Text(
                         serde_json::json!({
                             "type": "error",
-                            "raw": txt.unwrap_or_default().to_string(),
+                            "data": {
+                                "type": "unknown",
+                                "reason": format!("Unknown event type: {}", txt.unwrap_or_default())
+                            }
                         })
                         .to_string()
                         .into(),

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -123,6 +123,10 @@ async fn handle_connection(
                     )
                 }
                 Some("log") => {
+                    let type_value = match value.get("type").and_then(Value::as_str) {
+                        Some(v) => v.to_string(),
+                        None => continue,
+                    };
                     let device_id_value = match value.get("device").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
                         None => continue,
@@ -144,7 +148,7 @@ async fn handle_connection(
                     (
                         TelemetryEvent::LogUpdate(LogData {
                             id: nanoid::nanoid!(),
-                            r#type: "system".to_string(),
+                            r#type: type_value,
                             timestamp,
                             level: level.clone(),
                             message: message.clone(),

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -72,7 +72,7 @@ async fn handle_connection(
                         Some(v) => v.to_string(),
                         None => continue,
                     };
-                    let state = match value.get("state").and_then(Value::as_str) {
+                    let moving_state = match value.get("state").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
                         None => continue,
                     };
@@ -86,10 +86,7 @@ async fn handle_connection(
                         None => continue,
                     };
                     let accuracy = coords.get("accuracy").and_then(Value::as_f64);
-                    let speed = match coords.get("speed").and_then(Value::as_f64) {
-                        Some(v) => v,
-                        None => continue,
-                    };
+                    let speed = coords.get("speed").and_then(Value::as_f64).unwrap_or(0.0); // 欠損時は 0.0 を既定値とする
                     let timestamp = match value.get("timestamp").and_then(Value::as_u64) {
                         Some(v) => v,
                         None => continue,
@@ -102,16 +99,16 @@ async fn handle_connection(
                             lon,
                             accuracy,
                             speed,
-                            device: device_id.clone(), // 型を確認の上、不要なら削除
-                            state: state.clone(),      // 同上
-                            timestamp,                 // 型に応じて Option<u64> か u64
+                            device: device_id.clone(),
+                            state: moving_state.clone(),
+                            timestamp,
                         }),
                         Message::Text(
                             serde_json::json!({
                                 "id": nanoid::nanoid!(),
                                 "type": "location_update",
                                 "device": device_id,
-                                "state": state,
+                                "state": moving_state,
                                 "coords": {
                                     "latitude": lat,
                                     "longitude": lon,

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -388,6 +388,7 @@ pub async fn start_ws_server(app: Arc<AppHandle>) -> anyhow::Result<()> {
             for (_, subs) in st.subscribers.iter_mut() {
                 subs.retain(|_, tx| !tx.is_closed());
             }
+            st.subscribers.retain(|_, subs| !subs.is_empty());
         }
     });
 

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -70,26 +70,86 @@ async fn handle_connection(
                 Some("location_update") => {
                     let device_id = match value.get("device").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `device`",
+                                        "raw": value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let moving_state = match value.get("state").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `state`",
+                                        "raw": value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let coords = &value["coords"];
                     let lat = match coords.get("latitude").and_then(Value::as_f64) {
                         Some(v) => v,
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `coords.latitude`",
+                                        "raw": coords.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let lon = match coords.get("longitude").and_then(Value::as_f64) {
                         Some(v) => v,
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `coords.longitude`",
+                                        "raw": coords.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let accuracy = coords.get("accuracy").and_then(Value::as_f64);
                     let speed = coords.get("speed").and_then(Value::as_f64).unwrap_or(0.0); // 欠損時は 0.0 を既定値とする
                     let timestamp = match value.get("timestamp").and_then(Value::as_u64) {
                         Some(v) => v,
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `timestamp`",
+                                        "raw": value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
 
                     (
@@ -125,24 +185,84 @@ async fn handle_connection(
                 Some("log") => {
                     let device_id_value = match value.get("device").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `device`",
+                                        "raw": value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let timestamp = match value.get("timestamp").and_then(Value::as_u64) {
                         Some(v) => v,
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `timestamp`",
+                                        "raw": value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let log_value = &value["log"];
                     let type_value = match log_value.get("type").and_then(Value::as_str) {
-                        Some(v) => v.to_string(),     // "system" | "app" | "client"
-                        None => "system".to_string(), // 既定値を設定
+                        Some(v) => v.to_string(), // "system" | "app" | "client"
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `log.type`",
+                                        "raw": log_value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let level = match log_value.get("level").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `log.level`",
+                                        "raw": log_value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
                     let message = match log_value.get("message").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
-                        None => continue,
+                        None => {
+                            emit_event(
+                                app,
+                                &TelemetryEvent::Error(ErrorData {
+                                    r#type: "payload_parse_error".to_string(),
+                                    raw: serde_json::json!({
+                                        "error": "Could not parse `log.message`",
+                                        "raw": log_value.to_string(),
+                                    }),
+                                }),
+                            );
+                            continue;
+                        }
                     };
 
                     (

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -123,10 +123,6 @@ async fn handle_connection(
                     )
                 }
                 Some("log") => {
-                    let type_value = match value.get("type").and_then(Value::as_str) {
-                        Some(v) => v.to_string(),
-                        None => continue,
-                    };
                     let device_id_value = match value.get("device").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
                         None => continue,
@@ -136,6 +132,10 @@ async fn handle_connection(
                         None => continue,
                     };
                     let log_value = &value["log"];
+                    let type_value = match log_value.get("type").and_then(Value::as_str) {
+                        Some(v) => v.to_string(),     // "system" | "app" | "client"
+                        None => "system".to_string(), // 既定値を設定
+                    };
                     let level = match log_value.get("level").and_then(Value::as_str) {
                         Some(v) => v.to_string(),
                         None => continue,

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -157,7 +157,7 @@ async fn handle_connection(
                         Message::Text(
                             serde_json::json!({
                                 "id": nanoid::nanoid!(),
-                                "type": "log".to_string(),
+                                "type": "log",
                                 "timestamp": timestamp,
                                  "level": level,
                                  "message": message,
@@ -180,11 +180,11 @@ async fn handle_connection(
                     Message::Text(
                         serde_json::json!({
                         "id": nanoid::nanoid!(),
-                        "type": "log".to_string(),
+                        "type": "log",
                         "timestamp":chrono::Utc::now().timestamp_millis() as u64,
-                        "level": "info".to_string(),
-                        "message": "New subscriber added.".to_string(),
-                        "device": "THQ Client".to_string(),
+                        "level": "info",
+                        "message": "New subscriber added.",
+                        "device": "THQ Client",
                         })
                         .to_string()
                         .into(),

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -46,7 +46,13 @@ async fn handle_connection(
     // 読み取りループ
     while let Some(msg_result) = read.next().await {
         let msg = match msg_result {
-            Ok(msg) => msg,
+            Ok(msg) => match msg {
+                tokio_tungstenite::tungstenite::Message::Ping(payload) => {
+                    let _ = tx.try_send(tokio_tungstenite::tungstenite::Message::Pong(payload));
+                    continue;
+                }
+                _ => msg,
+            },
             Err(_) => break, // エラーが発生した場合はループを終了
         };
 

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -53,7 +53,19 @@ async fn handle_connection(
         if let Ok(text) = msg.to_text() {
             let value: Value = match serde_json::from_str(text) {
                 Ok(v) => v,
-                Err(_) => continue, // JSONパースエラーの場合は次のメッセージを処理
+                Err(e) => {
+                    emit_event(
+                        app,
+                        &TelemetryEvent::Error(ErrorData {
+                            r#type: "json_parse_error".to_string(),
+                            raw: serde_json::json!({
+                                "error": format!("JSON parse error: {}", e),
+                                "raw": text,
+                            }),
+                        }),
+                    );
+                    continue;
+                }
             };
 
             if let Some("subscribe") = value["type"].as_str() {

--- a/src-tauri/src/ws_server.rs
+++ b/src-tauri/src/ws_server.rs
@@ -64,10 +64,7 @@ async fn handle_connection(
                         app,
                         &TelemetryEvent::Error(ErrorData {
                             r#type: "json_parse_error".to_string(),
-                            raw: serde_json::json!({
-                                "error": format!("JSON parse error: {}", e),
-                                "raw": text,
-                            }),
+                            reason: format!("Failed to parse JSON: {}", e),
                         }),
                     );
                     continue;
@@ -93,10 +90,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `device`",
-                                        "raw": value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `device`: {}",
+                                        value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -109,10 +106,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `state`",
-                                        "raw": value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `state`: {}",
+                                        value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -126,10 +123,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `coords.latitude`",
-                                        "raw": coords.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `coords.latitude`: {}",
+                                        coords.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -142,10 +139,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `coords.longitude`",
-                                        "raw": coords.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `coords.longitude`: {}",
+                                        coords.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -160,10 +157,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `timestamp`",
-                                        "raw": value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `timestamp`: {}",
+                                        value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -208,10 +205,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `device`",
-                                        "raw": value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `device`: {}",
+                                        value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -224,10 +221,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `timestamp`",
-                                        "raw": value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `timestamp`: {}",
+                                        value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -241,10 +238,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `log.type`",
-                                        "raw": log_value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `log.type`: {}",
+                                        log_value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -257,10 +254,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `log.level`",
-                                        "raw": log_value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `log.level`: {}",
+                                        log_value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -273,10 +270,10 @@ async fn handle_connection(
                                 app,
                                 &TelemetryEvent::Error(ErrorData {
                                     r#type: "payload_parse_error".to_string(),
-                                    raw: serde_json::json!({
-                                        "error": "Could not parse `log.message`",
-                                        "raw": log_value.to_string(),
-                                    }),
+                                    reason: format!(
+                                        "Could not parse `log.message`: {}",
+                                        log_value.to_string()
+                                    ),
                                 }),
                             );
                             continue;
@@ -286,7 +283,7 @@ async fn handle_connection(
                     (
                         TelemetryEvent::LogUpdate(LogData {
                             id: nanoid::nanoid!(),
-                            r#type: type_value,
+                            r#type: type_value.clone(),
                             timestamp,
                             level: level.clone(),
                             message: message.clone(),
@@ -296,10 +293,13 @@ async fn handle_connection(
                             serde_json::json!({
                                 "id": nanoid::nanoid!(),
                                 "type": "log",
+                                "device": device_id_value,
                                 "timestamp": timestamp,
-                                 "level": level,
-                                 "message": message,
-                                 "device": device_id_value,
+                                "log": {
+                                    "type": type_value,
+                                    "level": level,
+                                    "message": message
+                                }
                             })
                             .to_string()
                             .into(),
@@ -317,12 +317,15 @@ async fn handle_connection(
                     }),
                     Message::Text(
                         serde_json::json!({
-                        "id": nanoid::nanoid!(),
-                        "type": "log",
-                        "timestamp":chrono::Utc::now().timestamp_millis() as u64,
-                        "level": "info",
-                        "message": "New subscriber added.",
-                        "device": "THQ Client",
+                            "id": nanoid::nanoid!(),
+                            "type": "log",
+                            "device": "THQ Client",
+                            "timestamp": chrono::Utc::now().timestamp_millis() as u64,
+                            "log": {
+                                "type": "system",
+                                "level": "info",
+                                "message": "New subscriber added."
+                            }
                         })
                         .to_string()
                         .into(),
@@ -331,10 +334,7 @@ async fn handle_connection(
                 txt => (
                     TelemetryEvent::Error(ErrorData {
                         r#type: "unknown".to_string(),
-                        raw: serde_json::json!({
-                            "error": "Unknown event type",
-                            "raw": txt.unwrap_or_default().to_string(),
-                        }),
+                        reason: format!("Unknown event type: {}", txt.unwrap_or_default()),
                     }),
                     Message::Text(
                         serde_json::json!({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import type { LocationData } from "./domain/commands";
 import { BAD_ACCURACY_THRESHOLD } from "./domain/threshold";
 
 function App() {
-  const { telemetryList, error, consoleLogs, isLocalServerAvailable } =
+  const { telemetryList, error, consoleLogs, isLocalServerEnabled } =
     useTelemetry();
 
   const latestTelemetry = useMemo(
@@ -86,8 +86,8 @@ function App() {
       <header className="p-4 bg-white dark:bg-black/30 backdrop-blur-md shadow-sm border-b border-gray-200 dark:border-white/15 sticky top-0 z-9999 w-full select-none cursor-default">
         <h1 className="font-bold">
           TrainLCD THQ
-          {isLocalServerAvailable !== null ? (
-            <span>({isLocalServerAvailable ? "Server" : "Client"})</span>
+          {isLocalServerEnabled !== null ? (
+            <span>({isLocalServerEnabled ? "Server" : "Client"})</span>
           ) : (
             <></>
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,16 +43,6 @@ function App() {
     return false;
   }, [latestTelemetry?.accuracy]);
 
-  const movingLogs = useMemo(
-    () => telemetryList.slice().sort((a, b) => b.timestamp - a.timestamp),
-    [telemetryList]
-  );
-
-  const sortedConsoleLogs = useMemo(
-    () => consoleLogs.slice().sort((a, b) => b.timestamp - a.timestamp),
-    [consoleLogs]
-  );
-
   const locations = useMemo<LatLngTuple[]>(
     () =>
       telemetryList
@@ -121,8 +111,8 @@ function App() {
 
         <div className="mt-4">
           <h3 className="text-md font-semibold mb-2">Moving Log</h3>
-          {movingLogs.length ? (
-            <MovingLogTable movingLogs={movingLogs} />
+          {telemetryList.length ? (
+            <MovingLogTable movingLogs={telemetryList} />
           ) : (
             <p className="text-gray-500 dark:text-gray-400">
               No moving log data available.
@@ -135,7 +125,7 @@ function App() {
           {error ? (
             <div className="mt-2">
               <p>Error Type: {error.type}</p>
-              <p>Raw Data: {JSON.stringify(error.raw)}</p>
+              <p>Reason: {error.reason}</p>
             </div>
           ) : (
             <p className="text-gray-500 dark:text-gray-400">
@@ -146,8 +136,8 @@ function App() {
 
         <div className="mt-4">
           <h3 className="text-md font-semibold mb-2">Logs</h3>
-          {sortedConsoleLogs.length ? (
-            <ConsoleLogTable logs={sortedConsoleLogs} />
+          {consoleLogs.length ? (
+            <ConsoleLogTable logs={consoleLogs} />
           ) : (
             <p className="text-gray-500 dark:text-gray-400">
               No log data available.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,16 @@ function App() {
     );
   }, [telemetryList]);
 
+  const movingLogs = useMemo(
+    () => telemetryList.slice().reverse(),
+    [telemetryList]
+  );
+
+  const sortedConsoleLogs = useMemo(
+    () => consoleLogs.slice().reverse(),
+    [consoleLogs]
+  );
+
   const badAccuracy = useMemo(() => {
     if (latestTelemetry?.accuracy === null) return false;
     if (latestTelemetry?.accuracy > BAD_ACCURACY_THRESHOLD) return true;
@@ -111,8 +121,8 @@ function App() {
 
         <div className="mt-4">
           <h3 className="text-md font-semibold mb-2">Moving Log</h3>
-          {telemetryList.length ? (
-            <MovingLogTable movingLogs={telemetryList} />
+          {movingLogs.length ? (
+            <MovingLogTable movingLogs={movingLogs} />
           ) : (
             <p className="text-gray-500 dark:text-gray-400">
               No moving log data available.
@@ -136,8 +146,8 @@ function App() {
 
         <div className="mt-4">
           <h3 className="text-md font-semibold mb-2">Logs</h3>
-          {consoleLogs.length ? (
-            <ConsoleLogTable logs={consoleLogs} />
+          {sortedConsoleLogs.length ? (
+            <ConsoleLogTable logs={sortedConsoleLogs} />
           ) : (
             <p className="text-gray-500 dark:text-gray-400">
               No log data available.

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -30,7 +30,7 @@ export type ErrorData = z.infer<typeof ErrorData>;
 
 export const LogData = z.object({
   id: z.string(),
-  type: z.enum(["system"]).optional(),
+  type: z.enum(["system", "app"]).optional(),
   timestamp: z.number(),
   level: z.enum(["debug", "info", "warn", "error"]),
   message: z.string(),

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -1,4 +1,4 @@
-import { listen } from "@tauri-apps/api/event";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { z } from "zod";
 
 export const MovingState = z.enum([
@@ -9,43 +9,49 @@ export const MovingState = z.enum([
 ]);
 export type MovingState = z.infer<typeof MovingState>;
 
-export const LocationData = z.object({
-  id: z.string(),
-  lat: z.number().finite().min(-90).max(90).nullable(),
-  lon: z.number().finite().min(-180).max(180).nullable(),
-  accuracy: z.number().finite().nonnegative().nullable(),
-  speed: z.number().finite().nonnegative().nullable(),
-  timestamp: z.number().int().nonnegative(),
-  state: MovingState,
-  device: z.string(),
-});
+export const LocationData = z
+  .object({
+    id: z.string(),
+    lat: z.number().finite().min(-90).max(90).nullable(),
+    lon: z.number().finite().min(-180).max(180).nullable(),
+    accuracy: z.number().finite().nonnegative().nullable(),
+    speed: z.number().finite().nonnegative().nullable(),
+    timestamp: z.number().int().nonnegative(),
+    state: MovingState,
+    device: z.string(),
+  })
+  .strict();
 export type LocationData = z.infer<typeof LocationData>;
 
-export const ErrorData = z.object({
-  type: z.enum([
-    "websocket_message_error",
-    "json_parse_error",
-    "payload_parse_error",
-    "accuracy_low",
-    "invalid_coords",
-    "unknown",
-  ]),
-  // TODO: 後で考える
-  raw: z.unknown(),
-});
+export const ErrorData = z
+  .object({
+    type: z.enum([
+      "websocket_message_error",
+      "json_parse_error",
+      "payload_parse_error",
+      "accuracy_low",
+      "invalid_coords",
+      "unknown",
+    ]),
+    // TODO: 後で考える
+    raw: z.unknown(),
+  })
+  .strict();
 export type ErrorData = z.infer<typeof ErrorData>;
 
-export const LogData = z.object({
-  id: z.string(),
-  // system: THQサーバーが発行したログ
-  // app: TrainLCDアプリが発行したログ
-  // client: THQクライアントが発行したログ
-  type: z.enum(["system", "app", "client"]).optional(),
-  timestamp: z.number().int().nonnegative(),
-  level: z.enum(["debug", "info", "warn", "error"]),
-  message: z.string(),
-  device: z.string(),
-});
+export const LogData = z
+  .object({
+    id: z.string(),
+    // system: THQサーバーが発行したログ
+    // app: TrainLCDアプリが発行したログ
+    // client: THQクライアントが発行したログ
+    type: z.enum(["system", "app", "client"]),
+    timestamp: z.number().int().nonnegative(),
+    level: z.enum(["debug", "info", "warn", "error"]),
+    message: z.string(),
+    device: z.string(),
+  })
+  .strict();
 export type LogData = z.infer<typeof LogData>;
 
 export const TelemetryEvent = z.discriminatedUnion("type", [
@@ -68,15 +74,19 @@ export function registerTelemetryListener(handlers: {
   onLocationUpdate?: (data: LocationData) => void;
   onError?: (error: ErrorData) => void;
   onLog?: (log: LogData) => void;
-}) {
+}): Promise<UnlistenFn> {
   return listen<unknown>("telemetry", (event) => {
     const parsedEvent = TelemetryEvent.safeParse(event.payload);
     if (!parsedEvent.success) {
-      console.error("Invalid telemetry event", parsedEvent.error);
-      handlers.onError?.({
-        type: "payload_parse_error",
-        raw: parsedEvent.error,
-      });
+      // 開発環境のみ生 payload をログ出力
+      if (import.meta.env.MODE === "development") {
+        console.error(
+          "Invalid telemetry event",
+          parsedEvent.error,
+          event.payload
+        );
+      }
+      handlers.onError?.({ type: "unknown", raw: event.payload });
       return;
     }
     const payload = parsedEvent.data;

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -2,95 +2,96 @@ import { listen } from "@tauri-apps/api/event";
 import { z } from "zod";
 
 export const MovingState = z.enum([
-	"arrived",
-	"approaching",
-	"passing",
-	"moving",
+  "arrived",
+  "approaching",
+  "passing",
+  "moving",
 ]);
 export type MovingState = z.infer<typeof MovingState>;
 
 export const LocationData = z.object({
-	id: z.string(),
-	lat: z.number().nullable(),
-	lon: z.number().nullable(),
-	accuracy: z.number().nullable(),
-	speed: z.number().nullable(),
-	timestamp: z.number(),
-	state: MovingState,
-	device: z.string(),
+  id: z.string(),
+  lat: z.number().nullable(),
+  lon: z.number().nullable(),
+  accuracy: z.number().nullable(),
+  speed: z.number().nullable(),
+  timestamp: z.number(),
+  state: MovingState,
+  device: z.string(),
 });
 export type LocationData = z.infer<typeof LocationData>;
 
 export const ErrorData = z.object({
-	type: z.enum(["accuracy_low", "invalid_coords", "unknown"]),
-	// TODO: 後で考える
-	raw: z.any(),
+  type: z.enum(["accuracy_low", "invalid_coords", "unknown"]),
+  // TODO: 後で考える
+  raw: z.any(),
 });
 export type ErrorData = z.infer<typeof ErrorData>;
 
 export const LogData = z.object({
-	id: z.string(),
-	timestamp: z.number(),
-	level: z.enum(["debug", "info", "warn", "error"]),
-	message: z.string(),
-	device: z.string(),
+  id: z.string(),
+  type: z.enum(["log"]),
+  timestamp: z.number(),
+  level: z.enum(["debug", "info", "warn", "error"]),
+  message: z.string(),
+  device: z.string(),
 });
 export type LogData = z.infer<typeof LogData>;
 
 export const TelemetryEvent = z.discriminatedUnion("type", [
-	z.object({
-		type: z.literal("location_update"),
-		data: LocationData,
-	}),
-	z.object({
-		type: z.literal("error"),
-		data: ErrorData,
-	}),
-	z.object({
-		type: z.literal("log"),
-		data: LogData,
-	}),
+  z.object({
+    type: z.literal("location_update"),
+    data: LocationData,
+  }),
+  z.object({
+    type: z.literal("error"),
+    data: ErrorData,
+  }),
+  z.object({
+    type: z.literal("log"),
+    data: LogData,
+  }),
 ]);
 export type TelemetryEvent = z.infer<typeof TelemetryEvent>;
 
 export function registerTelemetryListener(handlers: {
-	onLocationUpdate?: (data: LocationData) => void;
-	onError?: (error: ErrorData) => void;
-	onLog?: (log: LogData) => void;
+  onLocationUpdate?: (data: LocationData) => void;
+  onError?: (error: ErrorData) => void;
+  onLog?: (log: LogData) => void;
 }) {
-	return listen<TelemetryEvent>("telemetry", (event) => {
-		const payload = event.payload;
+  return listen<TelemetryEvent>("telemetry", (event) => {
+    const payload = event.payload;
 
-		switch (payload.type) {
-			case "location_update": {
-				const parsed = LocationData.safeParse(payload.data);
-				if (parsed.success) {
-					handlers.onLocationUpdate?.(parsed.data);
-					return;
-				}
-				console.error("Invalid location data", parsed.error);
-				handlers.onError?.({
-					type: "unknown",
-					raw: parsed.error,
-				});
-				break;
-			}
-			case "error":
-				handlers.onError?.(payload.data);
-				break;
-			case "log": {
-				const parsed = LogData.safeParse(payload.data);
-				if (parsed.success) {
-					handlers.onLog?.(parsed.data);
-					return;
-				}
-				console.error("Invalid log data", parsed.error);
-				handlers.onError?.({
-					type: "unknown",
-					raw: parsed.error,
-				});
-				break;
-			}
-		}
-	});
+    switch (payload.type) {
+      case "location_update": {
+        const parsed = LocationData.safeParse(payload.data);
+        if (parsed.success) {
+          handlers.onLocationUpdate?.(parsed.data);
+          return;
+        }
+        console.error("Invalid location data", parsed.error);
+        handlers.onError?.({
+          type: "unknown",
+          raw: parsed.error,
+        });
+        break;
+      }
+      case "error":
+        handlers.onError?.(payload.data);
+        break;
+      case "log": {
+        const parsed = LogData.safeParse(payload.data);
+        if (parsed.success) {
+          handlers.onLog?.(parsed.data);
+          return;
+        }
+        console.error("Invalid log data", parsed.error);
+        handlers.onError?.({
+          type: "unknown",
+          raw: parsed.error,
+        });
+        break;
+      }
+    }
+  });
 }

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -11,11 +11,11 @@ export type MovingState = z.infer<typeof MovingState>;
 
 export const LocationData = z.object({
   id: z.string(),
-  lat: z.number().nullable(),
-  lon: z.number().nullable(),
-  accuracy: z.number().nullable(),
-  speed: z.number().nullable(),
-  timestamp: z.number(),
+  lat: z.number().finite().min(-90).max(90).nullable(),
+  lon: z.number().finite().min(-180).max(180).nullable(),
+  accuracy: z.number().finite().nonnegative().nullable(),
+  speed: z.number().finite().nonnegative().nullable(),
+  timestamp: z.number().int().nonnegative(),
   state: MovingState,
   device: z.string(),
 });
@@ -24,13 +24,13 @@ export type LocationData = z.infer<typeof LocationData>;
 export const ErrorData = z.object({
   type: z.enum(["accuracy_low", "invalid_coords", "unknown"]),
   // TODO: 後で考える
-  raw: z.any(),
+  raw: z.unknown(),
 });
 export type ErrorData = z.infer<typeof ErrorData>;
 
 export const LogData = z.object({
   id: z.string(),
-  type: z.enum(["log"]),
+  type: z.enum(["system"]).optional(),
   timestamp: z.number(),
   level: z.enum(["debug", "info", "warn", "error"]),
   message: z.string(),

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -30,7 +30,10 @@ export type ErrorData = z.infer<typeof ErrorData>;
 
 export const LogData = z.object({
   id: z.string(),
-  type: z.enum(["system", "app"]).optional(),
+  // system: THQサーバーが発行したログ
+  // app: TrainLCDアプリが発行したログ
+  // client: THQクライアントが発行したログ
+  type: z.enum(["system", "app", "client"]).optional(),
   timestamp: z.number(),
   level: z.enum(["debug", "info", "warn", "error"]),
   message: z.string(),

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -33,8 +33,7 @@ export const ErrorData = z
       "invalid_coords",
       "unknown",
     ]),
-    // TODO: 後で考える
-    raw: z.unknown(),
+    reason: z.string(),
   })
   .strict();
 export type ErrorData = z.infer<typeof ErrorData>;
@@ -86,7 +85,10 @@ export function registerTelemetryListener(handlers: {
           event.payload
         );
       }
-      handlers.onError?.({ type: "unknown", raw: event.payload });
+      handlers.onError?.({
+        type: "unknown",
+        reason: `Invalid telemetry event: ${parsedEvent.error.message}`,
+      });
       return;
     }
     const payload = parsedEvent.data;

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -22,7 +22,14 @@ export const LocationData = z.object({
 export type LocationData = z.infer<typeof LocationData>;
 
 export const ErrorData = z.object({
-  type: z.enum(["accuracy_low", "invalid_coords", "unknown"]),
+  type: z.enum([
+    "websocket_message_error",
+    "json_parse_error",
+    "payload_parse_error",
+    "accuracy_low",
+    "invalid_coords",
+    "unknown",
+  ]),
   // TODO: 後で考える
   raw: z.unknown(),
 });
@@ -66,7 +73,10 @@ export function registerTelemetryListener(handlers: {
     const parsedEvent = TelemetryEvent.safeParse(event.payload);
     if (!parsedEvent.success) {
       console.error("Invalid telemetry event", parsedEvent.error);
-      handlers.onError?.({ type: "unknown", raw: parsedEvent.error });
+      handlers.onError?.({
+        type: "payload_parse_error",
+        raw: parsedEvent.error,
+      });
       return;
     }
     const payload = parsedEvent.data;

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -18,7 +18,7 @@ export const useTelemetry = () => {
 
   const handleReceivedLocationUpdate = useCallback(
     (data: LocationData) =>
-      setTelemetryList((prev) => [...prev, data].slice(-1000)),
+      setTelemetryList((prev) => [data, ...prev].slice(0, 1000)),
     [setTelemetryList]
   );
   const handleReceivedError = useCallback(
@@ -26,7 +26,7 @@ export const useTelemetry = () => {
     []
   );
   const handleReceivedLog = useCallback(
-    (data: LogData) => setConsoleLogs((prev) => [...prev, data].slice(-1000)),
+    (data: LogData) => setConsoleLogs((prev) => [data, ...prev].slice(0, 1000)),
     []
   );
 

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -38,7 +38,11 @@ export const useTelemetry = () => {
         if (!disposed) setIsLocalServerAvailable(avail);
       } catch (e) {
         console.error("Failed to check local server availability", e);
-        if (!disposed) setError({ type: "unknown", raw: e });
+        if (!disposed)
+          setError({
+            type: "unknown",
+            reason: e instanceof Error ? e.message : String(e),
+          });
       }
     };
     updateServerAvailabilityAsync();
@@ -64,7 +68,11 @@ export const useTelemetry = () => {
       })
       .catch((e) => {
         console.error("Failed to register telemetry listener", e);
-        if (!disposed) setError({ type: "unknown", raw: e });
+        if (!disposed)
+          setError({
+            type: "unknown",
+            reason: e instanceof Error ? e.message : String(e),
+          });
       });
     return () => {
       disposed = true;

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -1,6 +1,5 @@
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { useAtom } from "jotai";
-import uniqBy from "lodash/uniqBy";
 import { useCallback, useEffect, useState } from "react";
 import { telemetryListAtom } from "~/atoms/telemetryItem";
 import {
@@ -20,9 +19,9 @@ export const useTelemetry = () => {
   const handleLocationUpdate = useCallback(
     (data: LocationData) => {
       setTelemetryList((prev) => {
-        const newList = uniqBy([...prev, { ...data }], "id");
-        // 最大1,000件に制限してメモリ使用量を管理
-        return newList.slice(-1000);
+        const filtered = prev.filter((x) => x.id !== data.id);
+        // 最大1,000件に制限してメモリ使用量を管理（重複は最新を優先）
+        return [...filtered, { ...data }].slice(-1000);
       });
     },
     [setTelemetryList]
@@ -42,13 +41,18 @@ export const useTelemetry = () => {
       onError: (err) => setError(err),
       onLog: (log) =>
         setConsoleLogs((prev) => {
-          const newLogs = uniqBy([...prev, log], "id");
-          // コンソールログも最大1,000件に制限
-          return newLogs.slice(-1000);
+          const filtered = prev.filter((x) => x.id !== log.id);
+          // コンソールログも最大1,000件に制限（重複は最新を優先）
+          return [...filtered, log].slice(-1000);
         }),
-    }).then((fn) => {
-      unlisten = fn;
-    });
+    })
+      .then((fn) => {
+        unlisten = fn;
+      })
+      .catch((e) => {
+        console.error("Failed to register telemetry listener", e);
+        setError({ type: "unknown", raw: e });
+      });
     return () => {
       unlisten?.();
     };

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -18,7 +18,7 @@ export const useTelemetry = () => {
 
   const handleReceivedLocationUpdate = useCallback(
     (data: LocationData) =>
-      setTelemetryList((prev) => [data, ...prev].slice(0, 1000)),
+      setTelemetryList((prev) => [...prev, data].slice(-1000)),
     [setTelemetryList]
   );
   const handleReceivedError = useCallback(
@@ -26,7 +26,7 @@ export const useTelemetry = () => {
     []
   );
   const handleReceivedLog = useCallback(
-    (data: LogData) => setConsoleLogs((prev) => [data, ...prev].slice(0, 1000)),
+    (data: LogData) => setConsoleLogs((prev) => [...prev, data].slice(-1000)),
     []
   );
 

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -4,59 +4,60 @@ import uniqBy from "lodash/uniqBy";
 import { useCallback, useEffect, useState } from "react";
 import { telemetryListAtom } from "~/atoms/telemetryItem";
 import {
-	type ErrorData,
-	type LocationData,
-	type LogData,
-	registerTelemetryListener,
+  type ErrorData,
+  type LocationData,
+  type LogData,
+  registerTelemetryListener,
 } from "~/domain/commands";
 import { isLocalServerEnabledAsync } from "~/utils/server";
 
 export const useTelemetry = () => {
-	const [isLocalServerAvailable, setIsLocalServerAvailable] = useState(false);
-	const [error, setError] = useState<ErrorData | null>(null);
-	const [consoleLogs, setConsoleLogs] = useState<LogData[]>([]);
-	const [telemetryList, setTelemetryList] = useAtom(telemetryListAtom);
+  const [isLocalServerAvailable, setIsLocalServerAvailable] = useState(false);
+  const [error, setError] = useState<ErrorData | null>(null);
+  const [consoleLogs, setConsoleLogs] = useState<LogData[]>([]);
+  const [telemetryList, setTelemetryList] = useAtom(telemetryListAtom);
 
-	const handleLocationUpdate = useCallback(
-		(data: LocationData) => {
-			setTelemetryList((prev) =>
-				uniqBy(
-					[
-						...prev.slice(-9999), // 最大10,000件まで保持
-						{ ...data },
-					],
-					"id",
-				),
-			);
-		},
-		[setTelemetryList],
-	);
+  const handleLocationUpdate = useCallback(
+    (data: LocationData) => {
+      setTelemetryList((prev) => {
+        const newList = uniqBy([...prev, { ...data }], "id");
+        // 最大1,000件に制限してメモリ使用量を管理
+        return newList.slice(-1000);
+      });
+    },
+    [setTelemetryList]
+  );
 
-	useEffect(() => {
-		const updateServerAvailabilityAsync = async () => {
-			setIsLocalServerAvailable(await isLocalServerEnabledAsync());
-		};
-		updateServerAvailabilityAsync();
-	}, []);
+  useEffect(() => {
+    const updateServerAvailabilityAsync = async () => {
+      setIsLocalServerAvailable(await isLocalServerEnabledAsync());
+    };
+    updateServerAvailabilityAsync();
+  }, []);
 
-	useEffect(() => {
-		let unlisten: UnlistenFn;
-		registerTelemetryListener({
-			onLocationUpdate: handleLocationUpdate,
-			onError: (err) => setError(err),
-			onLog: (log) => setConsoleLogs((prev) => uniqBy([...prev, log], "id")),
-		}).then((fn) => {
-			unlisten = fn;
-		});
-		return () => {
-			unlisten?.();
-		};
-	}, [handleLocationUpdate]);
+  useEffect(() => {
+    let unlisten: UnlistenFn;
+    registerTelemetryListener({
+      onLocationUpdate: handleLocationUpdate,
+      onError: (err) => setError(err),
+      onLog: (log) =>
+        setConsoleLogs((prev) => {
+          const newLogs = uniqBy([...prev, log], "id");
+          // コンソールログも最大1,000件に制限
+          return newLogs.slice(-1000);
+        }),
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [handleLocationUpdate]);
 
-	return {
-		telemetryList,
-		error,
-		consoleLogs,
-		isLocalServerAvailable,
-	};
+  return {
+    telemetryList,
+    error,
+    consoleLogs,
+    isLocalServerAvailable,
+  };
 };

--- a/src/hooks/useTelemetry.ts
+++ b/src/hooks/useTelemetry.ts
@@ -11,7 +11,7 @@ import {
 import { isLocalServerEnabledAsync } from "~/utils/server";
 
 export const useTelemetry = () => {
-  const [isLocalServerAvailable, setIsLocalServerAvailable] = useState(false);
+  const [isLocalServerEnabled, setisLocalServerEnabled] = useState(false);
   const [error, setError] = useState<ErrorData | null>(null);
   const [consoleLogs, setConsoleLogs] = useState<LogData[]>([]);
   const [telemetryList, setTelemetryList] = useAtom(telemetryListAtom);
@@ -35,7 +35,7 @@ export const useTelemetry = () => {
     const updateServerAvailabilityAsync = async () => {
       try {
         const avail = await isLocalServerEnabledAsync();
-        if (!disposed) setIsLocalServerAvailable(avail);
+        if (!disposed) setisLocalServerEnabled(avail);
       } catch (e) {
         console.error("Failed to check local server availability", e);
         if (!disposed)
@@ -84,6 +84,6 @@ export const useTelemetry = () => {
     telemetryList,
     error,
     consoleLogs,
-    isLocalServerAvailable,
+    isLocalServerEnabled,
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 接続ごとの一意ID管理と自動クリーンアップ、定期掃除（60秒間隔）で安定した配信。
  - 送信キューを有界(1024)化し、送信失敗時に書き手タスクを終了。
  - registerTelemetryListenerがPromiseでUnlisten関数を返すよう改善。

- バグ修正
  - 不正なテキスト/JSONや欠損フィールドを防御的にスキップし、種類別のエラー通知(reason付き)を発行。
  - 切断時の送信タスク中止と個別登録解除を確実化。
  - リスナー登録失敗を捕捉してエラー状態へ反映。

- ドキュメント
  - WebSocketペイロード仕様と型定義を拡充（ログ種別・エラー種別・送受信形状の明確化）。

- その他
  - テレメトリ・ログ保持を最新1,000件に固定（重複削除を廃止）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->