### PR TITLE
line_id / station_id 追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker compose build --no-cache
 When `database_url`/`DATABASE_URL` is provided, the server connects to PostgreSQL,
 creates the tables if missing, and stores each incoming message:
 
-- `location_events`: `id`, `device`, `state`, `latitude`, `longitude`, `accuracy`, `speed`, `timestamp`, `recorded_at`
+- `location_events`: `id`, `device`, `state`, `station_id`, `line_id`, `latitude`, `longitude`, `accuracy`, `speed`, `timestamp`, `recorded_at`
 - `log_events`: `id`, `device`, `log_type`, `log_level`, `message`, `timestamp`, `recorded_at`
 
 Without a `database_url` the server still accepts WebSocket traffic but does not
@@ -75,6 +75,8 @@ persist messages.
   "type": "location_update",
   "device": "device-id",
   "state": "arrived | approaching | passing | moving",
+  "station_id": 123,
+  "line_id": 45,
   "coords": {
     "latitude": 35.0,
     "longitude": 139.0,
@@ -83,6 +85,8 @@ persist messages.
   },
   "timestamp": 1234567890
 }
+
+`station_id` is optional; omit it when not applicable. `line_id` is required.
 ```
 
 ### log

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -85,6 +85,9 @@ pub enum IncomingMessage {
         id: Option<String>,
         device: String,
         state: MovementState,
+        #[serde(default)]
+        station_id: Option<i32>,
+        line_id: i32,
         coords: Coords,
         timestamp: u64,
     },
@@ -110,6 +113,8 @@ pub struct OutgoingLocation {
     pub id: String,
     pub device: String,
     pub state: MovementState,
+    pub station_id: Option<i32>,
+    pub line_id: i32,
     pub coords: OutgoingCoords,
     pub timestamp: u64,
 }
@@ -174,6 +179,8 @@ mod tests {
             id: "id1".into(),
             device: "dev".into(),
             state: MovementState::Moving,
+            station_id: Some(42),
+            line_id: 7,
             coords: OutgoingCoords {
                 latitude: 1.0,
                 longitude: 2.0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- ロケーション情報トラッキングにステーション ID とライン ID フィールドを追加しました。ステーション ID は任意フィールド、ライン ID は必須フィールドです。これらはロケーション更新メッセージペイロードに含まれ、永続的なデータストレージに統合されます。

## ドキュメント
- README を更新して、新しいデータスキーマ、メッセージペイロード例、およびデータベーススキーマの変更内容を文書化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->